### PR TITLE
Sign up errors

### DIFF
--- a/RubyonRails/app/assets/config/manifest.js
+++ b/RubyonRails/app/assets/config/manifest.js
@@ -8,3 +8,4 @@
 //= link modalControlClientsIndex.js
 //= link modalControlGlobalModeratorIndex.js
 //= link application.css
+//= link registrationFormValidation.js

--- a/RubyonRails/app/assets/javascripts/accountSignupButtons.js
+++ b/RubyonRails/app/assets/javascripts/accountSignupButtons.js
@@ -26,12 +26,17 @@ function toggleFields() {
         let registrationKeyField = document.getElementById('registrationKeyField');
         let signUpCodeField = document.getElementById('signUpCodeField');
 
+        let registrationKey = document.getElementById('registrationKey');
+        let moderatorKey = document.getElementById('moderatorKey');
+
         if (registrationKeyField) {
             registrationKeyField.style.display = localModerator ? 'block' : 'none';
+            registrationKey.required = localModerator ? true : false;
         }
 
         if (signUpCodeField) {
             signUpCodeField.style.display = regularUser ? 'block' : 'none';
+            moderatorKey.required = regularUser ? true : false;
         }
 
     }

--- a/RubyonRails/app/assets/javascripts/registrationFormValidation.js
+++ b/RubyonRails/app/assets/javascripts/registrationFormValidation.js
@@ -1,0 +1,32 @@
+// This file is for validating the "account type" field of the registration form to ensure that an option is selected
+
+
+// Add listener to Sign up button
+document.getElementById("registration_form").addEventListener("submit", checkAccountType);
+
+// Check if the account_type variable has a value
+// if not, display an error message on form
+function checkAccountType(event) {
+    account_types = document.getElementsByName("account_type");
+    selected = Array.from(account_types).find(type => type.checked);
+    if (!selected){
+        // Prevent the form from being submitted and display error message
+        event.preventDefault();
+        document.getElementById("accountTypeErrorMessage").hidden = false;
+
+        // Add listeners to account type radio buttons
+        local_mod_button = document.getElementById("localModerator");
+        regular_user_button = document.getElementById("regularUser");
+
+        // If the user selects one, remove the error message
+        local_mod_button.addEventListener("change", removeAccountTypeErrorMessage);
+        regular_user_button.addEventListener("change", removeAccountTypeErrorMessage);
+    }
+    return
+}
+
+// Removes/hides error message
+function removeAccountTypeErrorMessage(){
+    document.getElementById("accountTypeErrorMessage").hidden = true;
+    return
+}

--- a/RubyonRails/app/controllers/registrations_controller.rb
+++ b/RubyonRails/app/controllers/registrations_controller.rb
@@ -113,16 +113,6 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def valid_registration_key?(key)
-    if key.present?
-      puts "key is present"
-    else
-      puts "key is not present"
-    end
-    if !key.used
-      puts "key is not used"
-    else
-      puts "key is used"
-    end
     key.present? && !key.used && (key.expiration.nil? || key.expiration > Time.current)
   end
 

--- a/RubyonRails/app/controllers/registrations_controller.rb
+++ b/RubyonRails/app/controllers/registrations_controller.rb
@@ -14,9 +14,6 @@ class RegistrationsController < Devise::RegistrationsController
       create_regular_user
     when 'local_moderator'
       create_local_moderator
-    else
-      flash[:alert] = 'Invalid account type.'
-      redirect_to new_user_registration_path and return
     end
   end
 
@@ -37,26 +34,26 @@ class RegistrationsController < Devise::RegistrationsController
 
     if local_moderator.present?
       Rails.logger.info("DEBUG: Local mod was present.")
-
+      
       # The user is associated with the tenant of the local moderator whose code was entered.
       user.tenant_id = local_moderator.tenant_id
 
       # Check if user record was saved before proceeding.
       if user.save
         # key.update(used: true)
-         flash[:notice] = 'Regular user was successfully created.'
+        flash[:notice] = 'Regular user was successfully created.'
         sign_in(:user, user)
         redirect_to root_path, notice: 'User was successfully created set up 2FA auth.'
       else
         # If user creation fails, render the registration form again with error messages.
         self.resource = user
-        @minimum_password_length = User.password_length.min
-        flash.now[:alert] = "Registration failed because of the following reason(s):<br> #{user.errors.full_messages.join("<br>")}".html_safe
-        render:new, status: :unprocessable_entity
+        display_error_messages(user)
+        render:new, status: :unprocessable_entity and return
       end
     else
+      self.resource = user
       flash[:alert] = 'Invalid moderator code.'
-      redirect_to new_user_registration_path and return
+      render:new, status: :unprocessable_entity and return
     end
   end
 
@@ -101,15 +98,14 @@ class RegistrationsController < Devise::RegistrationsController
         else
           # Handler for save failures
           self.resource = user
-          @minimum_password_length = User.password_length.min
-          flash.now[:alert] = "Registration failed because of the following reason(s):<br> #{user.errors.full_messages.join("<br>")}".html_safe
-          Rails.logger.info("DEBUG: Failed to save user: #{user.errors.full_messages}")
-          render:new, status: :unprocessable_entity
+          display_error_messages(user)
+          render:new, status: :unprocessable_entity and return
         end
       else
         # Handler for save failures
+        self.resource = user
         flash[:alert] = 'Invalid registration key.'
-        redirect_to new_user_registration_path and return
+        render:new, status: :unprocessable_entity and return
       end
     end
   end
@@ -117,10 +113,24 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def valid_registration_key?(key)
+    if key.present?
+      puts "key is present"
+    else
+      puts "key is not present"
+    end
+    if !key.used
+      puts "key is not used"
+    else
+      puts "key is used"
+    end
     key.present? && !key.used && (key.expiration.nil? || key.expiration > Time.current)
   end
 
-
+  def display_error_messages(user)
+    @minimum_password_length = User.password_length.min
+    flash.now[:alert] = "Registration failed because of the following reason(s):<br> #{user.errors.full_messages.join("<br>")}".html_safe
+    Rails.logger.info("DEBUG: Failed to save user: #{user.errors.full_messages}")
+  end
 
   private
 

--- a/RubyonRails/app/views/devise/registrations/new.html.erb
+++ b/RubyonRails/app/views/devise/registrations/new.html.erb
@@ -2,17 +2,17 @@
   <div class="container p-5 my-3 w-50 border rounded bg-white">
     <h2 class="display-2" style='padding-bottom:20px'><strong>Sign Up</strong></h2>
 
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {id: "registration_form"}) do |f| %>
       <!--- <%= render "devise/shared/error_messages", resource: resource %> --->
 
       <div class="form-group">
         <%= f.label :first_name %>
-        <%= f.text_field :fname, autofocus: true, class: "form-control form-control-lg", style: 'padding:10px;' %>
+        <%= f.text_field :fname, autofocus: true, class: "form-control form-control-lg", style: 'padding:10px;', required: true%>
       </div>
 
       <div class="form-group">
         <%= f.label :last_name %>
-        <%= f.text_field :lname, autofocus: true, class: "form-control form-control-lg", style: 'padding:10px;' %>
+        <%= f.text_field :lname, autofocus: true, class: "form-control form-control-lg", style: 'padding:10px;', required: true %>
       </div>
 
       <div class="form-group">
@@ -30,6 +30,7 @@
 
       <div class="form-group">
         <label>Select Account Type:</label><br />
+        <p id="accountTypeErrorMessage" hidden style="color: red;">Please select an account type.</p>
         <input type="radio" name="account_type" value="local_moderator" id="localModerator"> Create a Local Moderator<br />
         <input type="radio" name="account_type" value="regular_user" id="regularUser"> I Have a Sign-Up Code<br />
       </div>
@@ -37,18 +38,19 @@
       <!-- Registration Key Field -->
       <div class="form-group" id="registrationKeyField" style="display:none;">
         <%= f.label :verification_key %>
-        <%= f.text_field :verification_key, class: "form-control form-control-lg", style: 'padding:10px;' %>
+        <%= f.text_field :verification_key, class: "form-control form-control-lg", style: 'padding:10px;', id:"registrationKey"%>
       </div>
 
       <!-- Local Moderator Code Field -->
       <div class="form-group" id="signUpCodeField" style="display:none;">
         <%= f.label :moderator_code, "Enter Local Moderator Code" %>
-        <%= f.text_field :moderator_code, class: "form-control form-control-lg", style: 'padding:10px;' %>
+        <%= f.text_field :moderator_code, class: "form-control form-control-lg", style: 'padding:10px;', id:"moderatorKey"%>
       </div>
 
       <div class="actions">
-        <%= f.submit "Sign up", class: 'btn btn-primary btn-lg btn-block' %>
+        <%= f.submit "Sign up", class: 'btn btn-primary btn-lg btn-block', data: { disable_with: false } %>
       </div>
     <% end %>
   </div>
 </body>
+ <%= javascript_include_tag 'registrationFormValidation' %>

--- a/RubyonRails/config/environments/development.rb
+++ b/RubyonRails/config/environments/development.rb
@@ -81,7 +81,7 @@ Rails.application.configure do
     port: 587,
     domain: 'gmail.com',
     user_name: 'dichoticdataresearch@gmail.com',
-    password: 'sqcngtxqyrjdbncm', # It's recommended to use credentials from environment variables or encrypted secrets
+    password: ENV["PASSWORD_TWO"], # It's recommended to use credentials from environment variables or encrypted secrets ENV["PASSWORD_TWO"]
     authentication: 'plain',
     enable_starttls_auto: true
   }


### PR DESCRIPTION
Tasks:
 - Make the First and last name required 
 - Have the same form be rendered so that a user keeps the same inputs if the registration fails 
 - Display all the errors 

Files changed: 5

File: RubyonRails/app/views/devise/registrations/new.html.erb
- Added "required: True" to first name and last name fields.
- Added "data: { disable_with: false }" to Sign up button to prevent the button from being disabled with "event.preventDefault()" in registrationFormValidation.js when the presence of an account type is not found.
- Modified for use in accountSignupButtons.js and registrationFormValidation.js

File: RubyonRails/app/controllers/registrations_controller.rb
- Modified code to render the same form when user enters an invalid code.
- Modified code to display all errors messages when the user submits the form. (Incomplete)
	- Created function for displaying error messages to improve readability and reduce duplicate code.
	- [Initial fix: Modified/reordered code to add "Invalid registration key" to errors messages instead of checking the key first, then if invalid, not checking the rest of the form inputs. See Questions section for why this was reverted to the original code.]
	- Most complex part: Moving the "Invalid account type" error message. If the user submitted the form with more needed revisions (e.g., password was too short) but did not select an account type, the only error message that displayed was the "Invalid account type" message. Now, the form is not submitted if the user (A) does not select an account type or (B) does not enter a code after selecting an account type. In both cases, an error message/warning is displayed.

File: RubyonRails/app/assets/javascripts/accountSignupButtons.js
- Edited to make the respective registration code required when the user selects an account type.
	- Removes the need for the "Invalid account type" error, so this was removed from the create function in the registrations controller.

File: RubyonRails/app/assets/javascripts/registrationFormValidation.js
- Created for the scenario in which a user does not select an account type.
	- Prevents form from being submitted.
	- Displays and removes error message accordingly.

File: RubyonRails/app/assets/config/manifest.js
- added "//= link registrationFormValidation.js".

Questions:
- Is there a difference between functionalities of valid_registration_key in registrations_controller.rb and validate_verification_key in user.rb?
	- Only noticeable differences: valid_registration_key checks if the key is expired and is only used when trying to create a moderator.
	- Attempting to save the user already triggers the key validation in user.rb. Therefore, there are two checks in place for the key for the moderator creation.
	Suggestion: check the key's expiration in user.rb, remove from registrations_controller.rb
	- I kept the original order of the checks in case there is a major difference.
	- Original order checks moderator code or registration code first and if invalid, does not check rest of form. If this is the desired behavior, the order may be kept.

Additional Suggestions/Notes:
- Current error message in user.rb for an invalid registration key is not specific to regular users or moderators while the current flash alerts are. May need to change errors in user.rb to match if the valid_registration_key function is removed from the registrations controller.
- If the local_moderator.present? if-else statements are omitted from the registrations controller, both "Registration key is invalid." from user.rb and "Tenant must exist" error messages are displayed, these essentially serve the same purpose.
- Save account type selection when form is re-rendered.
- Fix only the verification being saved when the form is re-rendered but not the local moderator code. (Or make neither be saved and render a blank field for both when form is rendered.)
- Not allowing the form to be submitted when no password is entered. (Though it does cause an error message.)
- Styling can be more consistent.

